### PR TITLE
[BUGFIX] Journal CLI: enableFields-Bypass konsistent, Logging, effect…

### DIFF
--- a/Classes/Command/ProcessJournalEntriesCommand.php
+++ b/Classes/Command/ProcessJournalEntriesCommand.php
@@ -44,8 +44,16 @@ class ProcessJournalEntriesCommand extends Command
     {
         $io = new SymfonyStyle($input, $output);
         $dryRun = $input->getOption('dry-run');
+        $verbose = $output->isVerbose();
 
         $io->title('Journal-Einträge verarbeiten');
+
+        if ($verbose) {
+            $io->text([
+                sprintf('EXEC_TIME:       %s (%d)', date('Y-m-d H:i:s', (int) ($GLOBALS['EXEC_TIME'] ?? 0)), (int) ($GLOBALS['EXEC_TIME'] ?? 0)),
+                sprintf('SIM_ACCESS_TIME: %s (%d)', date('Y-m-d H:i:s', (int) ($GLOBALS['SIM_ACCESS_TIME'] ?? 0)), (int) ($GLOBALS['SIM_ACCESS_TIME'] ?? 0)),
+            ]);
+        }
 
         if ($dryRun) {
             $io->note('DRY-RUN Modus - Keine Änderungen werden gespeichert');
@@ -55,8 +63,18 @@ class ProcessJournalEntriesCommand extends Command
             $now = new \DateTime('now');
             $pendingEntries = $this->journalRepository->findPendingUntilDate($now);
             $pendingCount = 0;
+
+            $rows = [];
             foreach ($pendingEntries as $entry) {
                 $pendingCount++;
+                if ($verbose) {
+                    $rows[] = [
+                        $entry->getUid(),
+                        $entry->getMember(),
+                        $entry->getEntryType(),
+                        $entry->getEffectiveDate()?->format('Y-m-d H:i:s') ?? '-',
+                    ];
+                }
             }
 
             if ($pendingCount === 0) {
@@ -66,24 +84,29 @@ class ProcessJournalEntriesCommand extends Command
 
             $io->text(sprintf('Gefundene fällige Einträge: %d', $pendingCount));
 
+            if ($verbose && $rows !== []) {
+                $io->table(['Entry UID', 'Member UID', 'Typ', 'Effective Date'], $rows);
+            }
+
             if ($dryRun) {
                 $io->success(sprintf('%d Einträge würden verarbeitet werden.', $pendingCount));
                 return Command::SUCCESS;
             }
 
-            // Verarbeite die Einträge
             $processedCount = $this->journalService->processPendingEntries($now);
 
-            $io->success(sprintf('Erfolgreich %d Journal-Einträge verarbeitet.', $processedCount));
+            $io->success(sprintf('Erfolgreich %d von %d Journal-Einträgen verarbeitet.', $processedCount, $pendingCount));
             return Command::SUCCESS;
 
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             $io->error([
                 'Fehler beim Verarbeiten der Journal-Einträge:',
-                $e->getMessage(),
+                sprintf('[%s] %s', get_class($e), $e->getMessage()),
+                '',
+                sprintf('EXEC_TIME: %d, SIM_ACCESS_TIME: %d', (int) ($GLOBALS['EXEC_TIME'] ?? 0), (int) ($GLOBALS['SIM_ACCESS_TIME'] ?? 0)),
                 '',
                 'Stack Trace:',
-                $e->getTraceAsString()
+                $e->getTraceAsString(),
             ]);
             return Command::FAILURE;
         }

--- a/Classes/Domain/Repository/MemberJournalEntryRepository.php
+++ b/Classes/Domain/Repository/MemberJournalEntryRepository.php
@@ -97,8 +97,18 @@ class MemberJournalEntryRepository extends Repository
   public function findAllForMember(int $memberUid): iterable
   {
     $query = $this->createQuery();
-    $query->getQuerySettings()->setRespectStoragePage(false);
-    $query->matching($query->equals('member', $memberUid));
+    $querySettings = $query->getQuerySettings();
+    $querySettings->setRespectStoragePage(false);
+    $querySettings->setIgnoreEnableFields(true);
+    $query->setQuerySettings($querySettings);
+
+    $query->matching(
+      $query->logicalAnd(
+        $query->equals('member', $memberUid),
+        $query->equals('deleted', 0),
+        $query->equals('hidden', 0)
+      )
+    );
     $query->setOrderings(['entryDate' => QueryInterface::ORDER_DESCENDING]);
 
     return $query->execute();
@@ -112,7 +122,11 @@ class MemberJournalEntryRepository extends Repository
   public function findPendingCancellationRequest(int $memberUid): ?object
   {
     $query = $this->createQuery();
-    $query->getQuerySettings()->setRespectStoragePage(false);
+    $querySettings = $query->getQuerySettings();
+    $querySettings->setRespectStoragePage(false);
+    $querySettings->setIgnoreEnableFields(true);
+    $query->setQuerySettings($querySettings);
+
     $query->matching(
       $query->logicalAnd(
         $query->equals('member', $memberUid),
@@ -135,7 +149,11 @@ class MemberJournalEntryRepository extends Repository
   public function findPendingCancellationStatusChange(int $memberUid): ?object
   {
     $query = $this->createQuery();
-    $query->getQuerySettings()->setRespectStoragePage(false);
+    $querySettings = $query->getQuerySettings();
+    $querySettings->setRespectStoragePage(false);
+    $querySettings->setIgnoreEnableFields(true);
+    $query->setQuerySettings($querySettings);
+
     $query->matching(
       $query->logicalAnd(
         $query->equals('member', $memberUid),
@@ -159,7 +177,11 @@ class MemberJournalEntryRepository extends Repository
   public function findLastProcessedEntry(int $memberUid, string $entryType): ?object
   {
     $query = $this->createQuery();
-    $query->getQuerySettings()->setRespectStoragePage(false);
+    $querySettings = $query->getQuerySettings();
+    $querySettings->setRespectStoragePage(false);
+    $querySettings->setIgnoreEnableFields(true);
+    $query->setQuerySettings($querySettings);
+
     $query->matching(
       $query->logicalAnd(
         $query->equals('member', $memberUid),
@@ -189,7 +211,11 @@ class MemberJournalEntryRepository extends Repository
   public function findLastProcessedStatusEntryForStateProjection(int $memberUid): ?object
   {
     $query = $this->createQuery();
-    $query->getQuerySettings()->setRespectStoragePage(false);
+    $querySettings = $query->getQuerySettings();
+    $querySettings->setRespectStoragePage(false);
+    $querySettings->setIgnoreEnableFields(true);
+    $query->setQuerySettings($querySettings);
+
     $query->matching(
       $query->logicalAnd(
         $query->equals('member', $memberUid),

--- a/Classes/Service/MemberJournalService.php
+++ b/Classes/Service/MemberJournalService.php
@@ -5,6 +5,7 @@ namespace Quicko\Clubmanager\Service;
 use DateTime;
 use InvalidArgumentException;
 use Psr\EventDispatcher\EventDispatcherInterface;
+use Psr\Log\LoggerInterface;
 use Quicko\Clubmanager\Domain\Model\Member;
 use Quicko\Clubmanager\Domain\Model\MemberJournalEntry;
 use Quicko\Clubmanager\Domain\Repository\MemberJournalEntryRepository;
@@ -12,7 +13,6 @@ use Quicko\Clubmanager\Domain\Repository\MemberRepository;
 use Quicko\Clubmanager\Event\MemberStateChangedEvent;
 use Quicko\Clubmanager\Utils\SettingUtils;
 use TYPO3\CMS\Core\Database\ConnectionPool;
-use TYPO3\CMS\Core\Log\LogManager;
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Persistence\Generic\PersistenceManager;
@@ -25,6 +25,7 @@ class MemberJournalService
     protected MemberRepository $memberRepository,
     protected PersistenceManager $persistenceManager,
     protected EventDispatcherInterface $eventDispatcher,
+    protected LoggerInterface $logger,
   ) {
   }
 
@@ -126,21 +127,31 @@ class MemberJournalService
   public function processPendingEntries(?DateTime $referenceDate = null): int
   {
     $refDate = $referenceDate ?? new DateTime('now');
+
+    $this->logger->info('Processing pending journal entries', [
+      'referenceDate' => $refDate->format('Y-m-d H:i:s'),
+      'simAccessTime' => $GLOBALS['SIM_ACCESS_TIME'] ?? 'N/A',
+      'execTime' => $GLOBALS['EXEC_TIME'] ?? 'N/A',
+    ]);
+
     $pendingEntries = $this->journalRepository->findPendingUntilDate($refDate);
 
     $processedCount = 0;
+    $foundCount = 0;
     $now = new DateTime();
 
     foreach ($pendingEntries as $entry) {
+      ++$foundCount;
       $memberUid = $entry->getMember();
-      // Lade Member-Objekt
       $member = $this->memberRepository->findByUidWithoutStoragePage($memberUid);
 
       if (!$member instanceof Member) {
-        $logger = GeneralUtility::makeInstance(LogManager::class)->getLogger(__CLASS__);
-        $logger->warning('Member not found for journal entry, marking as processed', [
+        $this->logger->warning('Member not found for journal entry, marking as processed', [
           'entryUid' => $entry->getUid(),
           'memberUid' => $memberUid,
+          'effectiveDate' => $entry->getEffectiveDate()?->format('Y-m-d H:i:s'),
+          'entryType' => $entry->getEntryType(),
+          'simAccessTime' => $GLOBALS['SIM_ACCESS_TIME'] ?? 'N/A',
         ]);
         $entry->setProcessed($now);
         $this->journalRepository->update($entry);
@@ -161,22 +172,35 @@ class MemberJournalService
         $this->memberRepository->update($member);
         ++$processedCount;
 
-        $this->fireMemberChangedEvents($member, $oldState);
-      } catch (InvalidArgumentException $e) {
-        // Log error but continue with next entry
-        $logger = GeneralUtility::makeInstance(LogManager::class)->getLogger(__CLASS__);
-        $logger->error('Skipping invalid journal entry', [
+        $this->logger->debug('Journal entry processed', [
           'entryUid' => $entry->getUid(),
           'memberUid' => $memberUid,
+          'entryType' => $entry->getEntryType(),
+          'oldState' => $oldState,
+          'newState' => $member->getState(),
+          'effectiveDate' => $entry->getEffectiveDate()?->format('Y-m-d H:i:s'),
+        ]);
+
+        $this->fireMemberChangedEvents($member, $oldState);
+      } catch (InvalidArgumentException $e) {
+        $this->logger->error('Skipping invalid journal entry', [
+          'entryUid' => $entry->getUid(),
+          'memberUid' => $memberUid,
+          'entryType' => $entry->getEntryType(),
           'error' => $e->getMessage(),
         ]);
-        // Mark as processed to prevent retry loop
         $entry->setProcessed($now);
         $this->journalRepository->update($entry);
       }
     }
 
     $this->persistenceManager->persistAll();
+
+    $this->logger->info('Journal processing completed', [
+      'foundEntries' => $foundCount,
+      'processedEntries' => $processedCount,
+      'skippedEntries' => $foundCount - $processedCount,
+    ]);
 
     return $processedCount;
   }
@@ -263,9 +287,7 @@ class MemberJournalService
           $this->fireMemberChangedEvents($member, $oldState);
         }
       } catch (InvalidArgumentException $e) {
-        // Log error and mark as processed with error note
-        $logger = GeneralUtility::makeInstance(LogManager::class)->getLogger(__CLASS__);
-        $logger->error('Skipping invalid journal entry for member', [
+        $this->logger->error('Skipping invalid journal entry for member', [
           'entryUid' => $entry->getUid(),
           'memberUid' => $memberUid,
           'error' => $e->getMessage(),

--- a/Configuration/TCA/tx_clubmanager_domain_model_memberjournalentry.php
+++ b/Configuration/TCA/tx_clubmanager_domain_model_memberjournalentry.php
@@ -156,7 +156,7 @@ return [
       'label' => 'LLL:EXT:clubmanager/Resources/Private/Language/locallang_db.xlf:tx_clubmanager_domain_model_memberjournalentry.effective_date',
       'config' => [
         'type' => 'datetime',
-        'format' => 'date',
+        'format' => 'datetime',
         'default' => 0,
       ],
     ],


### PR DESCRIPTION
…ive_date datetime (refs #6132)

- setIgnoreEnableFields(true) in allen Repository-Methoden
- Logger per DI statt GeneralUtility::makeInstance
- Diagnostisches Logging mit SIM_ACCESS_TIME/EXEC_TIME
- effective_date TCA-Format von date auf datetime
- CLI-Command: verbose-Ausgabe, Throwable-Catch

Made-with: Cursor