### PR TITLE
Fix: CLI User Deactivation & Journal Entry Deletion

### DIFF
--- a/Classes/EventListener/FrontendUserSyncListener.php
+++ b/Classes/EventListener/FrontendUserSyncListener.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Quicko\Clubmanager\EventListener;
+
+use Psr\Log\LoggerInterface;
+use Quicko\Clubmanager\Domain\Model\Member;
+use Quicko\Clubmanager\Event\MemberStateChangedEvent;
+use TYPO3\CMS\Core\Attribute\AsEventListener;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+#[AsEventListener(identifier: 'clubmanager/frontend-user-sync')]
+final readonly class FrontendUserSyncListener
+{
+  public function __construct(
+    private LoggerInterface $logger,
+  ) {
+  }
+
+  public function __invoke(MemberStateChangedEvent $event): void
+  {
+    $shouldDisable = ($event->getNewState() !== Member::STATE_ACTIVE);
+
+    $connection = GeneralUtility::makeInstance(ConnectionPool::class)
+      ->getConnectionForTable('fe_users');
+
+    $affectedRows = $connection->update(
+      'fe_users',
+      ['disable' => $shouldDisable ? 1 : 0],
+      [
+        'clubmanager_member' => $event->getMemberUid(),
+        'deleted' => 0,
+      ]
+    );
+
+    if ($affectedRows > 0) {
+      $this->logger->info(
+        sprintf(
+          'Updated fe_users disable=%d for member %d (%d rows)',
+          $shouldDisable ? 1 : 0,
+          $event->getMemberUid(),
+          $affectedRows
+        )
+      );
+    }
+  }
+}

--- a/Classes/Service/MemberJournalProjectionService.php
+++ b/Classes/Service/MemberJournalProjectionService.php
@@ -2,14 +2,23 @@
 
 namespace Quicko\Clubmanager\Service;
 
+use Psr\EventDispatcher\EventDispatcherInterface;
 use Quicko\Clubmanager\Domain\Model\Member;
 use Quicko\Clubmanager\Domain\Model\MemberJournalEntry;
+use Quicko\Clubmanager\Event\MemberStateChangedEvent;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\Query\QueryBuilder;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 class MemberJournalProjectionService
 {
+  protected EventDispatcherInterface $eventDispatcher;
+
+  public function injectEventDispatcher(EventDispatcherInterface $eventDispatcher): void
+  {
+    $this->eventDispatcher = $eventDispatcher;
+  }
+
   public function projectMemberConsistency(int $memberUid): bool
   {
     if ($memberUid <= 0) {
@@ -58,6 +67,12 @@ class MemberJournalProjectionService
 
     if ($updates === []) {
       return false;
+    }
+
+    // Event muss ausgelöst werden, bevor der Member-Datensatz geändert wurde, da die Newsletter-Extension
+    // denn alten Status aus der Datenbank abfragt.
+    if (($newState = $updates['state'] ?? false) && $memberRecord['state'] !== $newState) {
+      $this->fireMemberStateChangedEvent($memberRecord['uid'], $memberRecord['state'], $newState);
     }
 
     $updates['tstamp'] = time();
@@ -221,7 +236,12 @@ class MemberJournalProjectionService
   {
     $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable($table);
     $queryBuilder->getRestrictions()->removeAll();
+
     return $queryBuilder;
   }
-}
 
+  protected function fireMemberStateChangedEvent(int $memberUid, int $oldState, int $newState): void
+  {
+    $this->eventDispatcher->dispatch(new MemberStateChangedEvent($memberUid, $oldState, $newState));
+  }
+}

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -9,6 +9,9 @@ services:
 
   Quicko\Clubmanager\Service\MemberJournalService:
     public: true
+  
+  Quicko\Clubmanager\Service\MemberJournalProjectionService:
+    public: true
 
   Quicko\Clubmanager\Utils\UniversalTypoScriptService:
     public: true


### PR DESCRIPTION
- Fixed FE user deactivation in CLI-triggered journal tasks.
- Status and related subscriptions (e.g., newsletter) are now correctly recalculated when journal entries are deleted.